### PR TITLE
Implement battery status component for all items

### DIFF
--- a/BATTERY_STATUS_IMPLEMENTATION.md
+++ b/BATTERY_STATUS_IMPLEMENTATION.md
@@ -1,0 +1,61 @@
+# Автоматическое добавление BatteryItemStatusComponent
+
+## Описание
+
+Реализована система автоматического добавления `BatteryItemStatusComponent` к предметам с батареями. Теперь компонент добавляется автоматически и не требует ручного указания в YAML файлах.
+
+## Что изменилось
+
+### 1. Создана новая система: `BatteryItemStatusAutoSystem`
+
+**Файл:** `Content.Server/Power/EntitySystems/BatteryItemStatusAutoSystem.cs`
+
+Система автоматически добавляет `BatteryItemStatusComponent` к сущностям, которые:
+- Имеют компонент `ItemComponent` (могут быть осмотрены)
+- Имеют либо `BatteryComponent`, либо `PowerCellSlotComponent`
+
+### 2. События, которые обрабатывает система:
+
+- `MapInitEvent` для `BatteryComponent` - когда предмет с батареей инициализируется
+- `MapInitEvent` для `PowerCellSlotComponent` - когда предмет со слотом для батареи инициализируется  
+- `MapInitEvent` для `ItemComponent` - когда предмет инициализируется (проверяет наличие батарей)
+- `EntInsertedIntoContainerMessage` для `PowerCellSlotComponent` - когда батарея вставляется в слот
+
+### 3. Удалены ручные добавления компонента
+
+Из следующих файлов удалены строки `- type: BatteryItemStatus`:
+- `Resources/Prototypes/Entities/Objects/Weapons/security.yml`
+- `Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml`
+- `Resources/Prototypes/Entities/Objects/Tools/jammer.yml`
+- `Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml`
+
+## Как это работает
+
+1. Когда предмет с батареей загружается из прототипа, срабатывает событие `MapInitEvent`
+2. Система проверяет, является ли предмет осматриваемым (`ItemComponent`)
+3. Если да, проверяет наличие батареи (`BatteryComponent` или `PowerCellSlotComponent`)
+4. Если батарея есть, автоматически добавляет `BatteryItemStatusComponent`
+5. Компонент отображает статус батареи при осмотре предмета
+
+## Преимущества
+
+- **Автоматизация**: Больше не нужно вручную добавлять компонент к каждому предмету
+- **Консистентность**: Все предметы с батареями автоматически получают отображение статуса
+- **Меньше ошибок**: Невозможно забыть добавить компонент к новому предмету с батареей
+
+## Примеры предметов, которые получают автоматический статус:
+
+- Электрошокеры (stunbaton, stunprod)
+- Фонарики (flashlights)
+- Энергетическое оружие (laser guns)
+- Радиоглушители (jammers)
+- Голопроекторы (holoprojectors)
+- И все остальные предметы с компонентами `Battery` или `PowerCellSlot` + `Item`
+
+## Тестирование
+
+Система протестирована на нескольких типах предметов:
+- ✅ Предметы с `BatteryComponent`
+- ✅ Предметы с `PowerCellSlotComponent`
+- ✅ Удаление всех ручных добавлений компонента
+- ✅ Корректное отображение статуса батареи при осмотре

--- a/Content.Server/Power/EntitySystems/BatteryItemStatusAutoSystem.cs
+++ b/Content.Server/Power/EntitySystems/BatteryItemStatusAutoSystem.cs
@@ -1,0 +1,69 @@
+using Content.Shared.Power.Components;
+using Content.Server.Power.Components;
+using Content.Shared.PowerCell.Components;
+using Content.Shared.Item;
+using Robust.Shared.Containers;
+
+namespace Content.Server.Power.EntitySystems;
+
+/// <summary>
+/// Automatically adds BatteryItemStatusComponent to items that have batteries,
+/// making battery status visible when examining items.
+/// </summary>
+public sealed class BatteryItemStatusAutoSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        
+        // Add battery status component when BatteryComponent is properly initialized
+        SubscribeLocalEvent<BatteryComponent, MapInitEvent>(OnBatteryMapInit);
+        
+        // Add battery status component when PowerCellSlotComponent is properly initialized
+        SubscribeLocalEvent<PowerCellSlotComponent, MapInitEvent>(OnPowerCellSlotMapInit);
+        
+        // Also handle when ItemComponent is added to entities that already have batteries
+        SubscribeLocalEvent<ItemComponent, MapInitEvent>(OnItemMapInit);
+        
+        // Handle power cell insertion into slots
+        SubscribeLocalEvent<PowerCellSlotComponent, EntInsertedIntoContainerMessage>(OnCellInserted);
+    }
+
+    private void OnBatteryMapInit(EntityUid uid, BatteryComponent component, MapInitEvent args)
+    {
+        TryAddBatteryStatus(uid);
+    }
+
+    private void OnPowerCellSlotMapInit(EntityUid uid, PowerCellSlotComponent component, MapInitEvent args)
+    {
+        TryAddBatteryStatus(uid);
+    }
+
+    private void OnItemMapInit(EntityUid uid, ItemComponent component, MapInitEvent args)
+    {
+        TryAddBatteryStatus(uid);
+    }
+
+    private void OnCellInserted(EntityUid uid, PowerCellSlotComponent component, EntInsertedIntoContainerMessage args)
+    {
+        // When a power cell is inserted, ensure the host has battery status
+        TryAddBatteryStatus(uid);
+    }
+
+    private void TryAddBatteryStatus(EntityUid uid)
+    {
+        // Only add to items (things that can be examined)
+        if (!HasComp<ItemComponent>(uid))
+            return;
+
+        // Don't add if already has the component
+        if (HasComp<BatteryItemStatusComponent>(uid))
+            return;
+
+        // Check if the entity has a battery or power cell slot
+        if (!HasComp<BatteryComponent>(uid) && !HasComp<PowerCellSlotComponent>(uid))
+            return;
+
+        EnsureComp<BatteryItemStatusComponent>(uid);
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -24,7 +24,6 @@
   - type: Tag
     tags:
       - HolosignProjector
-  - type: BatteryItemStatus
 
 - type: entity
   parent: Holoprojector

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -36,7 +36,6 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
-  - type: BatteryItemStatus
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -45,7 +45,6 @@
   - type: Battery
     maxCharge: 360
     startingCharge: 360
-  - type: BatteryItemStatus
   - type: UseDelay
   - type: Item
     heldPrefix: off

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -50,7 +50,6 @@
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
-  - type: BatteryItemStatus
   - type: UseDelay
   - type: Item
     heldPrefix: off


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR automates the addition of `BatteryItemStatusComponent` to items that have batteries, removing the need for manual prototype entries.

## Why / Balance
This change streamlines prototype definitions, ensures all relevant items consistently display battery status upon examination, and prevents oversights when adding new battery-powered items. No direct balance changes.

## Technical details
*   Introduces `BatteryItemStatusAutoSystem` (`Content.Server/Power/EntitySystems/BatteryItemStatusAutoSystem.cs`).
*   This system listens for `MapInitEvent` on `BatteryComponent`, `PowerCellSlotComponent`, and `ItemComponent`, and `EntInsertedIntoContainerMessage` on `PowerCellSlotComponent`.
*   It automatically adds `BatteryItemStatusComponent` to any entity that has both an `ItemComponent` and either a `BatteryComponent` or `PowerCellSlotComponent`.
*   Removed manual `BatteryItemStatus` entries from `security.yml`, `stunprod.yml`, `jammer.yml`, and `holoprojectors.yml`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.io/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Battery status is now automatically displayed for all items with batteries or power cell slots upon examination, removing the need for manual component additions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ff2f812-b69a-4715-ae56-e2410577f9b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ff2f812-b69a-4715-ae56-e2410577f9b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>