### PR TITLE
Удалить параметр ChargeName

### DIFF
--- a/Content.Client/Charges/Components/ChargeItemStatusComponent.cs
+++ b/Content.Client/Charges/Components/ChargeItemStatusComponent.cs
@@ -15,13 +15,6 @@ namespace Content.Client.Charges.Components;
 public sealed partial class ChargeItemStatusComponent : Component
 {
     /// <summary>
-    /// Optional descriptive name for what the charges represent (e.g., "charges", "uses", "shots").
-    /// If not set, defaults to "charges".
-    /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public string ChargeName = "charge-status-name-charges";
-
-    /// <summary>
     /// Whether to show a recovery timer if auto-recharge is available.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Client/Charges/UI/ChargeStatusControl.cs
+++ b/Content.Client/Charges/UI/ChargeStatusControl.cs
@@ -49,15 +49,14 @@ public sealed class ChargeStatusControl : PollingItemStatusControl<ChargeStatusC
                 nextRecharge = nextRechargeTime;
         }
 
-        return new Data(currentCharges, maxCharges, nextRecharge, _parent.Comp.ChargeName);
+        return new Data(currentCharges, maxCharges, nextRecharge);
     }
 
     protected override void Update(in Data data)
     {
         var markup = Loc.GetString("charge-status-count",
             ("current", data.CurrentCharges),
-            ("max", data.MaxCharges),
-            ("name", Loc.GetString(data.ChargeName)));
+            ("max", data.MaxCharges));
 
         if (data.NextRecharge.HasValue)
         {
@@ -68,5 +67,5 @@ public sealed class ChargeStatusControl : PollingItemStatusControl<ChargeStatusC
         _label.SetMarkup(markup);
     }
 
-    public readonly record struct Data(int CurrentCharges, int MaxCharges, TimeSpan? NextRecharge, string ChargeName);
+    public readonly record struct Data(int CurrentCharges, int MaxCharges, TimeSpan? NextRecharge);
 }

--- a/Resources/Locale/en-US/items/item-status.ftl
+++ b/Resources/Locale/en-US/items/item-status.ftl
@@ -8,10 +8,8 @@ battery-status-switchable-state = { $state ->
 battery-status-state = State: {$state}
 
 # Charge Status
-charge-status-count = {$name}: [color=white]{$current}/{$max}[/color]
+charge-status-count = Сharges: [color=white]{$current}/{$max}[/color]
 charge-status-recharge = Recharge: [color=yellow]{$seconds}s[/color]
-charge-status-name-charges = Сharges
-charge-status-name-uses = Uses
 
 # Tank Pressure Status
 tank-pressure-status = Press.: [color=orange]{$pressure} kPa[/color]

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -148,7 +148,6 @@
     - type: LimitedCharges
       maxCharges: 5
     - type: ChargeItemStatus
-      chargeName: charge-status-name-charges
     - type: MeleeWeapon
       wideAnimationRotation: 180
       damage:


### PR DESCRIPTION
```
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes the `ChargeName` parameter from the charge status display and updates the FTL string to a fixed "Charges:".

## Why / Balance
This change simplifies the charge status display by removing the ability to configure the name (e.g., "Charges", "Uses"). The display will now consistently show "Charges:" for all items with a charge status, as per the user's request.

## Technical details
- Removed `ChargeName` field from `ChargeItemStatusComponent`.
- Updated `ChargeStatusControl` to no longer use or pass the `ChargeName` parameter.
- Modified `Resources/Locale/en-US/items/item-status.ftl` to remove `charge-status-name-charges` and `charge-status-name-uses`, and updated `charge-status-count` to `Сharges: [color=white]{$current}/{$max}[/color]`.
- Removed the `chargeName` field from `ChargeItemStatus` component in `security.yml` prototypes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A (text change)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.io/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Simplified charge status display to always show "Charges:" instead of a configurable name.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-23158e37-1593-407a-b5c0-f7467501c536">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23158e37-1593-407a-b5c0-f7467501c536">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>