### PR TITLE
Refactor botany system to ECS

### DIFF
--- a/Content.Server/Botany/Components/HarvestComponent.cs
+++ b/Content.Server/Botany/Components/HarvestComponent.cs
@@ -1,0 +1,27 @@
+using Content.Server.Botany.Systems;
+
+namespace Content.Server.Botany.Components;
+
+[RegisterComponent]
+[DataDefinition]
+public sealed partial class HarvestComponent : Component
+{
+    /// <summary>
+    /// Harvest options are NoRepeat(plant is removed on harvest), Repeat(Plant makes produce every Production ticks),
+    /// and SelfHarvest (Repeat, plus produce is dropped on the ground near the plant automatically)
+    /// </summary>
+    [DataField]
+    public HarvestType HarvestRepeat = HarvestType.NoRepeat;
+
+    /// <summary>
+    /// Whether the plant is currently ready for harvest.
+    /// </summary>
+    [ViewVariables]
+    public bool ReadyForHarvest = false;
+
+    /// <summary>
+    /// The last time this plant was harvested.
+    /// </summary>
+    [ViewVariables]
+    public float LastHarvestTime = 0f;
+}

--- a/Content.Server/Botany/Components/HarvestComponent.cs
+++ b/Content.Server/Botany/Components/HarvestComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Botany.Components;
 
 [RegisterComponent]
 [DataDefinition]
-public sealed partial class HarvestComponent : Component
+public sealed partial class HarvestComponent : PlantGrowthComponent
 {
     /// <summary>
     /// Harvest options are NoRepeat(plant is removed on harvest), Repeat(Plant makes produce every Production ticks),

--- a/Content.Server/Botany/Components/PlantChemicalsComponent.cs
+++ b/Content.Server/Botany/Components/PlantChemicalsComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.Botany.Components;
+
+[RegisterComponent]
+[DataDefinition]
+public sealed partial class PlantChemicalsComponent : Component
+{
+    /// <summary>
+    /// The chemicals that this plant produces and their quantities.
+    /// </summary>
+    [DataField]
+    public Dictionary<string, SeedChemQuantity> Chemicals = new();
+}

--- a/Content.Server/Botany/Components/PlantCosmeticsComponent.cs
+++ b/Content.Server/Botany/Components/PlantCosmeticsComponent.cs
@@ -1,0 +1,45 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Botany.Components;
+
+[RegisterComponent]
+[DataDefinition]
+public sealed partial class PlantCosmeticsComponent : Component
+{
+    /// <summary>
+    /// The RSI path for the plant sprites.
+    /// </summary>
+    [DataField(required: true)]
+    public ResPath PlantRsi { get; set; } = default!;
+
+    /// <summary>
+    /// The icon state for the plant.
+    /// </summary>
+    [DataField]
+    public string PlantIconState { get; set; } = "produce";
+
+    /// <summary>
+    /// Screams random sound from collection SoundCollectionSpecifier
+    /// </summary>
+    [DataField]
+    public SoundSpecifier ScreamSound = new SoundCollectionSpecifier("PlantScreams", AudioParams.Default.WithVolume(-10));
+
+    /// <summary>
+    /// If true, AAAAAAAAAAAHHHHHHHHHHH!
+    /// </summary>
+    [DataField("screaming")]
+    public bool CanScream;
+
+    /// <summary>
+    /// Which kind of kudzu this plant will turn into if it kuzuifies.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string KudzuPrototype = "WeakKudzu";
+
+    /// <summary>
+    /// If true, this plant turns into it's KudzuPrototype when the PlantHolder's WeedLevel hits this plant's WeedHighLevelThreshold.
+    /// </summary>
+    [DataField]
+    public bool TurnIntoKudzu;
+}

--- a/Content.Server/Botany/Components/PlantProductsComponent.cs
+++ b/Content.Server/Botany/Components/PlantProductsComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Botany.Components;
+
+[RegisterComponent]
+[DataDefinition]
+public sealed partial class PlantProductsComponent : Component
+{
+    /// <summary>
+    /// The entity prototypes that are spawned when this type of seed is harvested.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
+    public List<string> ProductPrototypes = new();
+
+    /// <summary>
+    /// The entity prototype that is spawned when this type of seed is extracted from produce using a seed extractor.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string PacketPrototype = "SeedBase";
+}

--- a/Content.Server/Botany/Components/PlantTraitsComponent.cs
+++ b/Content.Server/Botany/Components/PlantTraitsComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Botany.Components;
 
 [RegisterComponent]
 [DataDefinition]
-public sealed partial class PlantTraitsComponent : Component
+public sealed partial class PlantTraitsComponent : PlantGrowthComponent
 {
     /// <summary>
     /// The plant's max health.

--- a/Content.Server/Botany/Components/PlantTraitsComponent.cs
+++ b/Content.Server/Botany/Components/PlantTraitsComponent.cs
@@ -1,0 +1,68 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Botany.Components;
+
+[RegisterComponent]
+[DataDefinition]
+public sealed partial class PlantTraitsComponent : Component
+{
+    /// <summary>
+    /// The plant's max health.
+    /// </summary>
+    [DataField]
+    public float Endurance = 100f;
+
+    /// <summary>
+    /// How many produce are created on harvest.
+    /// </summary>
+    [DataField]
+    public int Yield;
+
+    /// <summary>
+    /// The number of growth ticks this plant can be alive for. Plants take high damage levels when Age > Lifespan.
+    /// </summary>
+    [DataField]
+    public float Lifespan;
+
+    /// <summary>
+    /// The number of growth ticks it takes for a plant to reach its final growth stage.
+    /// </summary>
+    [DataField]
+    public float Maturation;
+
+    /// <summary>
+    /// The number of growth ticks it takes for a plant to be (re-)harvestable. Shouldn't be lower than Maturation.
+    /// </summary>
+    [DataField]
+    public float Production;
+
+    /// <summary>
+    /// How many different sprites appear before the plant is fully grown.
+    /// </summary>
+    [DataField]
+    public int GrowthStages = 6;
+
+    /// <summary>
+    /// A scalar for sprite size and chemical quantity on the produce. Caps at 100.
+    /// </summary>
+    [DataField]
+    public float Potency = 1f;
+
+    /// <summary>
+    /// If true, produce can't be put into the seed maker.
+    /// </summary>
+    [DataField]
+    public bool Seedless = false;
+
+    /// <summary>
+    /// If true, a sharp tool is required to harvest this plant.
+    /// </summary>
+    [DataField]
+    public bool Ligneous;
+
+    /// <summary>
+    /// If false, rapidly decrease health while growing. Adds a bit of challenge to keep mutated plants alive via Unviable's frequency.
+    /// </summary>
+    [DataField]
+    public bool Viable = true;
+}

--- a/Content.Server/Botany/Systems/HarvestSystem.cs
+++ b/Content.Server/Botany/Systems/HarvestSystem.cs
@@ -1,0 +1,153 @@
+using Content.Server.Botany.Components;
+using Content.Server.Hands.Systems;
+using Content.Server.Popups;
+using Content.Shared.Botany;
+using Content.Shared.Hands.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Botany.Systems;
+
+public sealed class HarvestSystem : EntitySystem
+{
+    [Dependency] private readonly BotanySystem _botany = default!;
+    [Dependency] private readonly HandsSystem _hands = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly PlantHolderSystem _plantHolder = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<HarvestComponent, OnPlantGrowEvent>(OnPlantGrow);
+        SubscribeLocalEvent<HarvestComponent, InteractHandEvent>(OnInteractHand);
+    }
+
+    private void OnPlantGrow(EntityUid uid, HarvestComponent component, OnPlantGrowEvent args)
+    {
+        if (!TryComp<PlantHolderComponent>(uid, out var plantHolder) || 
+            !TryComp<PlantTraitsComponent>(uid, out var traits))
+            return;
+
+        if (plantHolder.Dead || plantHolder.Seed == null)
+            return;
+
+        // Check if plant is ready for harvest
+        if (plantHolder.Age >= traits.Production)
+        {
+            var timeSinceLastHarvest = plantHolder.Age - component.LastHarvestTime;
+            if (timeSinceLastHarvest >= traits.Production && !component.ReadyForHarvest)
+            {
+                component.ReadyForHarvest = true;
+                plantHolder.UpdateSpriteAfterUpdate = true;
+            }
+        }
+    }
+
+    private void OnInteractHand(EntityUid uid, HarvestComponent component, InteractHandEvent args)
+    {
+        if (!TryComp<PlantHolderComponent>(uid, out var plantHolder) ||
+            !TryComp<PlantTraitsComponent>(uid, out var traits) ||
+            !TryComp<PlantProductsComponent>(uid, out var products))
+            return;
+
+        if (!component.ReadyForHarvest || plantHolder.Dead)
+            return;
+
+        // Check if sharp tool is required
+        if (traits.Ligneous)
+        {
+            if (!_hands.TryGetActiveItem(args.User, out var activeItem) || 
+                !_botany.CanHarvest(plantHolder.Seed, activeItem))
+            {
+                _popup.PopupCursor(Loc.GetString("plant-holder-component-ligneous-cant-harvest-message"), args.User);
+                return;
+            }
+        }
+
+        // Perform harvest
+        DoHarvest(uid, args.User, component, plantHolder, traits, products);
+    }
+
+    public void DoHarvest(EntityUid plantUid, EntityUid user, HarvestComponent? harvestComp = null, 
+        PlantHolderComponent? plantHolder = null, PlantTraitsComponent? traits = null, PlantProductsComponent? products = null)
+    {
+        if (!Resolve(plantUid, ref harvestComp, ref plantHolder, ref traits, ref products))
+            return;
+
+        if (plantHolder.Dead)
+        {
+            // Remove dead plant
+            _plantHolder.RemovePlant(plantUid, plantHolder);
+            AfterHarvest(plantUid, harvestComp, plantHolder);
+            return;
+        }
+
+        if (!harvestComp.ReadyForHarvest)
+            return;
+
+        // Spawn products
+        var yield = traits.Yield;
+        for (int i = 0; i < yield; i++)
+        {
+            foreach (var productPrototype in products.ProductPrototypes)
+            {
+                var product = Spawn(productPrototype, Transform(plantUid).Coordinates);
+                
+                // Apply mutations to product
+                if (TryComp<ProduceComponent>(product, out var produce) && plantHolder.Seed != null)
+                {
+                    produce.Seed = plantHolder.Seed;
+                    _botany.ProduceGrown(product, produce);
+                }
+            }
+        }
+
+        // Handle harvest type
+        switch (harvestComp.HarvestRepeat)
+        {
+            case HarvestType.NoRepeat:
+                _plantHolder.RemovePlant(plantUid, plantHolder);
+                break;
+            case HarvestType.Repeat:
+            case HarvestType.SelfHarvest:
+                harvestComp.ReadyForHarvest = false;
+                harvestComp.LastHarvestTime = plantHolder.Age;
+                break;
+        }
+
+        AfterHarvest(plantUid, harvestComp, plantHolder);
+    }
+
+    private void AfterHarvest(EntityUid uid, HarvestComponent component, PlantHolderComponent plantHolder)
+    {
+        // Play scream sound if applicable
+        if (TryComp<PlantCosmeticsComponent>(uid, out var cosmetics) && cosmetics.CanScream)
+        {
+            _audio.PlayPvs(cosmetics.ScreamSound, uid);
+        }
+
+        // Update sprite
+        _plantHolder.UpdateSprite(uid, plantHolder);
+    }
+
+    public void AutoHarvest(EntityUid uid, HarvestComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        if (!component.ReadyForHarvest)
+            return;
+
+        DoHarvest(uid, uid, component);
+    }
+}

--- a/Content.Server/Botany/Systems/PlantGrowthSystem.cs
+++ b/Content.Server/Botany/Systems/PlantGrowthSystem.cs
@@ -78,18 +78,45 @@ public abstract class PlantGrowthSystem : EntitySystem
         if (component == null || component.Seed == null)
             return;
 
+        var maturation = 0f;
+        var yield = 0;
+        var readyForHarvest = false;
+
+        // Try to get values from new components
+        if (TryComp<PlantTraitsComponent>(component.Owner, out var traits))
+        {
+            maturation = traits.Maturation;
+            yield = traits.Yield;
+        }
+        else
+        {
+            // Fallback to old system
+            maturation = component.Seed.Maturation;
+            yield = component.Seed.Yield;
+        }
+
+        if (TryComp<HarvestComponent>(component.Owner, out var harvest))
+        {
+            readyForHarvest = harvest.ReadyForHarvest;
+        }
+        else
+        {
+            // Fallback to old system
+            readyForHarvest = component.Harvest;
+        }
+
         if (amount > 0)
         {
-            if (component.Age < component.Seed.Maturation)
+            if (component.Age < maturation)
                 component.Age += amount;
-            else if (!component.Harvest && component.Seed.Yield > 0f)
+            else if (!readyForHarvest && yield > 0f)
                 component.LastProduce -= amount;
         }
         else
         {
-            if (component.Age < component.Seed.Maturation)
+            if (component.Age < maturation)
                 component.SkipAging++;
-            else if (!component.Harvest && component.Seed.Yield > 0f)
+            else if (!readyForHarvest && yield > 0f)
                 component.LastProduce += amount;
         }
     }

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -906,9 +906,14 @@ public sealed class PlantHolderSystem : EntitySystem
     private void EnsureDefaultGrowthComponents(EntityUid uid)
     {
         EnsureComp<PlantComponent>(uid);
-        EnsureComp<BasicGrowthComponent>(uid);
-        EnsureComp<AtmosphericGrowthComponent>(uid);
-        EnsureComp<WeedPestGrowthComponent>(uid);
-        EnsureComp<ToxinsComponent>(uid);
+        // Only add default components if they're not already present from growthComponents
+        if (!HasComp<BasicGrowthComponent>(uid))
+            EnsureComp<BasicGrowthComponent>(uid);
+        if (!HasComp<AtmosphericGrowthComponent>(uid))
+            EnsureComp<AtmosphericGrowthComponent>(uid);
+        if (!HasComp<WeedPestGrowthComponent>(uid))
+            EnsureComp<WeedPestGrowthComponent>(uid);
+        if (!HasComp<ToxinsComponent>(uid))
+            EnsureComp<ToxinsComponent>(uid);
     }
 }

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -6,8 +6,8 @@
   mutationPrototypes:
     - meatwheat
   growthComponents:
-    - BasicGrowthComponent
-      nutrientConsumption: 0.4
+    - !type:BasicGrowthComponent
+        nutrientConsumption: 0.4
   plantTraits:
     endurance: 100
     yield: 3
@@ -24,12 +24,10 @@
         Min: 1
         Max: 20
         PotencyDivisor: 20
-        Inherent: true
       Flour:
         Min: 5
         Max: 20
         PotencyDivisor: 20
-        Inherent: true
   plantProducts:
     productPrototypes:
       - WheatBushel
@@ -43,8 +41,8 @@
   noun: seeds-noun-seeds
   displayName: seeds-meatwheat-display-name
   growthComponents:
-    - BasicGrowthComponent
-      nutrientConsumption: 0.4
+    - !type:BasicGrowthComponent
+        nutrientConsumption: 0.4
   plantTraits:
     endurance: 100
     yield: 3
@@ -61,12 +59,10 @@
         Min: 1
         Max: 20
         PotencyDivisor: 20
-        Inherent: true
       UncookedAnimalProteins:
         Min: 5
         Max: 20
         PotencyDivisor: 20
-        Inherent: true
   plantProducts:
     productPrototypes:
       - MeatwheatBushel
@@ -80,8 +76,8 @@
   noun: seeds-noun-seeds
   displayName: seeds-oat-display-name
   growthComponents:
-    - BasicGrowthComponent
-      nutrientConsumption: 0.4
+    - !type:BasicGrowthComponent
+        nutrientConsumption: 0.4
   plantTraits:
     endurance: 100
     yield: 3
@@ -98,12 +94,10 @@
         Min: 1
         Max: 20
         PotencyDivisor: 20
-        Inherent: true
       Oats:
         Min: 5
         Max: 20
         PotencyDivisor: 20
-        Inherent: true
   plantProducts:
     productPrototypes:
       - OatBushel
@@ -119,10 +113,10 @@
   mutationPrototypes:
     - mimana
   growthComponents:
-    - BasicGrowthComponent
-      waterConsumption: 0.6
-    - AtmosphericGrowthComponent
-      idealHeat: 298
+    - !type:BasicGrowthComponent
+        waterConsumption: 0.6
+    - !type:AtmosphericGrowthComponent
+        idealHeat: 298
   plantTraits:
     endurance: 100
     yield: 2
@@ -139,12 +133,10 @@
         Min: 1
         Max: 4
         PotencyDivisor: 25
-        Inherent: true
       Nutriment:
         Min: 1
         Max: 2
         PotencyDivisor: 50
-        Inherent: true
   plantProducts:
     productPrototypes:
       - FoodBanana

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -8,14 +8,15 @@
   growthComponents:
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
-  plantTraits:
-    endurance: 100
-    yield: 3
-    lifespan: 25
-    maturation: 6
-    production: 3
-    growthStages: 6
-    potency: 5
+    - !type:PlantTraitsComponent
+        endurance: 100
+        yield: 3
+        lifespan: 25
+        maturation: 6
+        production: 3
+        growthStages: 6
+        potency: 5
+        harvestRepeat: NoRepeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/wheat.rsi
   plantChemicals:
@@ -32,8 +33,6 @@
     productPrototypes:
       - WheatBushel
     packetPrototype: WheatSeeds
-  harvest:
-    harvestRepeat: NoRepeat
 
 - type: seed
   id: meatwheat
@@ -43,14 +42,15 @@
   growthComponents:
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
-  plantTraits:
-    endurance: 100
-    yield: 3
-    lifespan: 25
-    maturation: 6
-    production: 3
-    growthStages: 6
-    potency: 5
+    - !type:PlantTraitsComponent
+        endurance: 100
+        yield: 3
+        lifespan: 25
+        maturation: 6
+        production: 3
+        growthStages: 6
+        potency: 5
+        harvestRepeat: NoRepeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
   plantChemicals:
@@ -67,8 +67,6 @@
     productPrototypes:
       - MeatwheatBushel
     packetPrototype: MeatwheatSeeds
-  harvest:
-    harvestRepeat: NoRepeat
 
 - type: seed
   id: oat
@@ -78,14 +76,15 @@
   growthComponents:
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
-  plantTraits:
-    endurance: 100
-    yield: 3
-    lifespan: 25
-    maturation: 6
-    production: 3
-    growthStages: 6
-    potency: 5
+    - !type:PlantTraitsComponent
+        endurance: 100
+        yield: 3
+        lifespan: 25
+        maturation: 6
+        production: 3
+        growthStages: 6
+        potency: 5
+        harvestRepeat: NoRepeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/oat.rsi
   plantChemicals:
@@ -102,8 +101,6 @@
     productPrototypes:
       - OatBushel
     packetPrototype: OatSeeds
-  harvest:
-    harvestRepeat: NoRepeat
 
 - type: seed
   id: banana
@@ -117,14 +114,15 @@
         waterConsumption: 0.6
     - !type:AtmosphericGrowthComponent
         idealHeat: 298
-  plantTraits:
-    endurance: 100
-    yield: 2
-    lifespan: 50
-    maturation: 6
-    production: 6
-    growthStages: 6
-    potency: 1
+    - !type:PlantTraitsComponent
+        endurance: 100
+        yield: 2
+        lifespan: 50
+        maturation: 6
+        production: 6
+        growthStages: 6
+        potency: 1
+        harvestRepeat: Repeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/banana.rsi
   plantChemicals:
@@ -141,8 +139,6 @@
     productPrototypes:
       - FoodBanana
     packetPrototype: BananaSeeds
-  harvest:
-    harvestRepeat: Repeat
 
 - type: seed
   id: mimana

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -9,44 +9,39 @@
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
   plantTraits:
-    !type:PlantTraitsComponent
-      endurance: 100
-      yield: 3
-      lifespan: 25
-      maturation: 6
-      production: 3
-      growthStages: 6
-      potency: 5
-      seedless: false
-      ligneous: false
-      viable: true
+    endurance: 100
+    yield: 3
+    lifespan: 25
+    maturation: 6
+    production: 3
+    growthStages: 6
+    potency: 5
+    seedless: false
+    ligneous: false
+    viable: true
   plantCosmetics:
-    !type:PlantCosmeticsComponent
-      plantRsi: Objects/Specific/Hydroponics/wheat.rsi
-      plantIconState: produce
-      canScream: false
-      turnIntoKudzu: false
+    plantRsi: Objects/Specific/Hydroponics/wheat.rsi
+    plantIconState: produce
+    canScream: false
+    turnIntoKudzu: false
   plantChemicals:
-    !type:PlantChemicalsComponent
-      chemicals:
-        Nutriment:
-          Min: 1
-          Max: 20
-          PotencyDivisor: 20
-          Inherent: true
-        Flour:
-          Min: 5
-          Max: 20
-          PotencyDivisor: 20
-          Inherent: true
+    chemicals:
+      Nutriment:
+        Min: 1
+        Max: 20
+        PotencyDivisor: 20
+        Inherent: true
+      Flour:
+        Min: 5
+        Max: 20
+        PotencyDivisor: 20
+        Inherent: true
   plantProducts:
-    !type:PlantProductsComponent
-      productPrototypes:
-        - WheatBushel
-      packetPrototype: WheatSeeds
+    productPrototypes:
+      - WheatBushel
+    packetPrototype: WheatSeeds
   harvest:
-    !type:HarvestComponent
-      harvestRepeat: NoRepeat
+    harvestRepeat: NoRepeat
 
 - type: seed
   id: meatwheat
@@ -57,44 +52,39 @@
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
   plantTraits:
-    !type:PlantTraitsComponent
-      endurance: 100
-      yield: 3
-      lifespan: 25
-      maturation: 6
-      production: 3
-      growthStages: 6
-      potency: 5
-      seedless: false
-      ligneous: false
-      viable: true
+    endurance: 100
+    yield: 3
+    lifespan: 25
+    maturation: 6
+    production: 3
+    growthStages: 6
+    potency: 5
+    seedless: false
+    ligneous: false
+    viable: true
   plantCosmetics:
-    !type:PlantCosmeticsComponent
-      plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
-      plantIconState: produce
-      canScream: false
-      turnIntoKudzu: false
+    plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
+    plantIconState: produce
+    canScream: false
+    turnIntoKudzu: false
   plantChemicals:
-    !type:PlantChemicalsComponent
-      chemicals:
-        Nutriment:
-          Min: 1
-          Max: 20
-          PotencyDivisor: 20
-          Inherent: true
-        UncookedAnimalProteins:
-          Min: 5
-          Max: 20
-          PotencyDivisor: 20
-          Inherent: true
+    chemicals:
+      Nutriment:
+        Min: 1
+        Max: 20
+        PotencyDivisor: 20
+        Inherent: true
+      UncookedAnimalProteins:
+        Min: 5
+        Max: 20
+        PotencyDivisor: 20
+        Inherent: true
   plantProducts:
-    !type:PlantProductsComponent
-      productPrototypes:
-        - MeatwheatBushel
-      packetPrototype: MeatwheatSeeds
+    productPrototypes:
+      - MeatwheatBushel
+    packetPrototype: MeatwheatSeeds
   harvest:
-    !type:HarvestComponent
-      harvestRepeat: NoRepeat
+    harvestRepeat: NoRepeat
 
 - type: seed
   id: oat
@@ -117,32 +107,28 @@
       ligneous: false
       viable: true
   plantCosmetics:
-    !type:PlantCosmeticsComponent
-      plantRsi: Objects/Specific/Hydroponics/oat.rsi
-      plantIconState: produce
-      canScream: false
-      turnIntoKudzu: false
+    plantRsi: Objects/Specific/Hydroponics/oat.rsi
+    plantIconState: produce
+    canScream: false
+    turnIntoKudzu: false
   plantChemicals:
-    !type:PlantChemicalsComponent
-      chemicals:
-        Nutriment:
-          Min: 1
-          Max: 20
-          PotencyDivisor: 20
-          Inherent: true
-        Oats:
-          Min: 5
-          Max: 20
-          PotencyDivisor: 20
-          Inherent: true
+    chemicals:
+      Nutriment:
+        Min: 1
+        Max: 20
+        PotencyDivisor: 20
+        Inherent: true
+      Oats:
+        Min: 5
+        Max: 20
+        PotencyDivisor: 20
+        Inherent: true
   plantProducts:
-    !type:PlantProductsComponent
-      productPrototypes:
-        - OatBushel
-      packetPrototype: OatSeeds
+    productPrototypes:
+      - OatBushel
+    packetPrototype: OatSeeds
   harvest:
-    !type:HarvestComponent
-      harvestRepeat: NoRepeat
+    harvestRepeat: NoRepeat
 
 - type: seed
   id: banana
@@ -157,44 +143,39 @@
     - !type:AtmosphericGrowthComponent
         idealHeat: 298
   plantTraits:
-    !type:PlantTraitsComponent
-      endurance: 100
-      yield: 2
-      lifespan: 50
-      maturation: 6
-      production: 6
-      growthStages: 6
-      potency: 1
-      seedless: false
-      ligneous: false
-      viable: true
+    endurance: 100
+    yield: 2
+    lifespan: 50
+    maturation: 6
+    production: 6
+    growthStages: 6
+    potency: 1
+    seedless: false
+    ligneous: false
+    viable: true
   plantCosmetics:
-    !type:PlantCosmeticsComponent
-      plantRsi: Objects/Specific/Hydroponics/banana.rsi
-      plantIconState: produce
-      canScream: false
-      turnIntoKudzu: false
+    plantRsi: Objects/Specific/Hydroponics/banana.rsi
+    plantIconState: produce
+    canScream: false
+    turnIntoKudzu: false
   plantChemicals:
-    !type:PlantChemicalsComponent
-      chemicals:
-        Vitamin:
-          Min: 1
-          Max: 4
-          PotencyDivisor: 25
-          Inherent: true
-        Nutriment:
-          Min: 1
-          Max: 2
-          PotencyDivisor: 50
-          Inherent: true
+    chemicals:
+      Vitamin:
+        Min: 1
+        Max: 4
+        PotencyDivisor: 25
+        Inherent: true
+      Nutriment:
+        Min: 1
+        Max: 2
+        PotencyDivisor: 50
+        Inherent: true
   plantProducts:
-    !type:PlantProductsComponent
-      productPrototypes:
-        - FoodBanana
-      packetPrototype: BananaSeeds
+    productPrototypes:
+      - FoodBanana
+    packetPrototype: BananaSeeds
   harvest:
-    !type:HarvestComponent
-      harvestRepeat: Repeat
+    harvestRepeat: Repeat
 
 - type: seed
   id: mimana

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -6,8 +6,8 @@
   mutationPrototypes:
     - meatwheat
   growthComponents:
-    - !type:BasicGrowthComponent
-        nutrientConsumption: 0.4
+    - BasicGrowthComponent
+      nutrientConsumption: 0.4
   plantTraits:
     endurance: 100
     yield: 3
@@ -16,14 +16,8 @@
     production: 3
     growthStages: 6
     potency: 5
-    seedless: false
-    ligneous: false
-    viable: true
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/wheat.rsi
-    plantIconState: produce
-    canScream: false
-    turnIntoKudzu: false
   plantChemicals:
     chemicals:
       Nutriment:
@@ -49,8 +43,8 @@
   noun: seeds-noun-seeds
   displayName: seeds-meatwheat-display-name
   growthComponents:
-    - !type:BasicGrowthComponent
-        nutrientConsumption: 0.4
+    - BasicGrowthComponent
+      nutrientConsumption: 0.4
   plantTraits:
     endurance: 100
     yield: 3
@@ -59,14 +53,8 @@
     production: 3
     growthStages: 6
     potency: 5
-    seedless: false
-    ligneous: false
-    viable: true
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
-    plantIconState: produce
-    canScream: false
-    turnIntoKudzu: false
   plantChemicals:
     chemicals:
       Nutriment:
@@ -92,25 +80,18 @@
   noun: seeds-noun-seeds
   displayName: seeds-oat-display-name
   growthComponents:
-    - !type:BasicGrowthComponent
-        nutrientConsumption: 0.4
+    - BasicGrowthComponent
+      nutrientConsumption: 0.4
   plantTraits:
-    !type:PlantTraitsComponent
-      endurance: 100
-      yield: 3
-      lifespan: 25
-      maturation: 6
-      production: 3
-      growthStages: 6
-      potency: 5
-      seedless: false
-      ligneous: false
-      viable: true
+    endurance: 100
+    yield: 3
+    lifespan: 25
+    maturation: 6
+    production: 3
+    growthStages: 6
+    potency: 5
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/oat.rsi
-    plantIconState: produce
-    canScream: false
-    turnIntoKudzu: false
   plantChemicals:
     chemicals:
       Nutriment:
@@ -138,10 +119,10 @@
   mutationPrototypes:
     - mimana
   growthComponents:
-    - !type:BasicGrowthComponent
-        waterConsumption: 0.6
-    - !type:AtmosphericGrowthComponent
-        idealHeat: 298
+    - BasicGrowthComponent
+      waterConsumption: 0.6
+    - AtmosphericGrowthComponent
+      idealHeat: 298
   plantTraits:
     endurance: 100
     yield: 2
@@ -150,14 +131,8 @@
     production: 6
     growthStages: 6
     potency: 1
-    seedless: false
-    ligneous: false
-    viable: true
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/banana.rsi
-    plantIconState: produce
-    canScream: false
-    turnIntoKudzu: false
   plantChemicals:
     chemicals:
       Vitamin:

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -3,114 +3,198 @@
   name: seeds-wheat-name
   noun: seeds-noun-seeds
   displayName: seeds-wheat-display-name
-  plantRsi: Objects/Specific/Hydroponics/wheat.rsi
-  packetPrototype: WheatSeeds
-  productPrototypes:
-    - WheatBushel
   mutationPrototypes:
     - meatwheat
-  lifespan: 25
-  maturation: 6
-  production: 3
-  yield: 3
-  potency: 5
   growthComponents:
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
-  chemicals:
-    Nutriment:
-      Min: 1
-      Max: 20
-      PotencyDivisor: 20
-    Flour:
-      Min: 5
-      Max: 20
-      PotencyDivisor: 20
+  plantTraits:
+    !type:PlantTraitsComponent
+      endurance: 100
+      yield: 3
+      lifespan: 25
+      maturation: 6
+      production: 3
+      growthStages: 6
+      potency: 5
+      seedless: false
+      ligneous: false
+      viable: true
+  plantCosmetics:
+    !type:PlantCosmeticsComponent
+      plantRsi: Objects/Specific/Hydroponics/wheat.rsi
+      plantIconState: produce
+      canScream: false
+      turnIntoKudzu: false
+  plantChemicals:
+    !type:PlantChemicalsComponent
+      chemicals:
+        Nutriment:
+          Min: 1
+          Max: 20
+          PotencyDivisor: 20
+          Inherent: true
+        Flour:
+          Min: 5
+          Max: 20
+          PotencyDivisor: 20
+          Inherent: true
+  plantProducts:
+    !type:PlantProductsComponent
+      productPrototypes:
+        - WheatBushel
+      packetPrototype: WheatSeeds
+  harvest:
+    !type:HarvestComponent
+      harvestRepeat: NoRepeat
 
 - type: seed
   id: meatwheat
   name: seeds-meatwheat-name
   noun: seeds-noun-seeds
   displayName: seeds-meatwheat-display-name
-  plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
-  packetPrototype: MeatwheatSeeds
-  productPrototypes:
-    - MeatwheatBushel
-  lifespan: 25
-  maturation: 6
-  production: 3
-  yield: 3
-  potency: 5
   growthComponents:
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
-  chemicals:
-    Nutriment:
-      Min: 1
-      Max: 20
-      PotencyDivisor: 20
-    UncookedAnimalProteins:
-      Min: 5
-      Max: 20
-      PotencyDivisor: 20
+  plantTraits:
+    !type:PlantTraitsComponent
+      endurance: 100
+      yield: 3
+      lifespan: 25
+      maturation: 6
+      production: 3
+      growthStages: 6
+      potency: 5
+      seedless: false
+      ligneous: false
+      viable: true
+  plantCosmetics:
+    !type:PlantCosmeticsComponent
+      plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
+      plantIconState: produce
+      canScream: false
+      turnIntoKudzu: false
+  plantChemicals:
+    !type:PlantChemicalsComponent
+      chemicals:
+        Nutriment:
+          Min: 1
+          Max: 20
+          PotencyDivisor: 20
+          Inherent: true
+        UncookedAnimalProteins:
+          Min: 5
+          Max: 20
+          PotencyDivisor: 20
+          Inherent: true
+  plantProducts:
+    !type:PlantProductsComponent
+      productPrototypes:
+        - MeatwheatBushel
+      packetPrototype: MeatwheatSeeds
+  harvest:
+    !type:HarvestComponent
+      harvestRepeat: NoRepeat
 
 - type: seed
   id: oat
   name: seeds-oat-name
   noun: seeds-noun-seeds
   displayName: seeds-oat-display-name
-  plantRsi: Objects/Specific/Hydroponics/oat.rsi
-  packetPrototype: OatSeeds
-  productPrototypes:
-    - OatBushel
-  lifespan: 25
-  maturation: 6
-  production: 3
-  yield: 3
-  potency: 5
   growthComponents:
     - !type:BasicGrowthComponent
         nutrientConsumption: 0.4
-  chemicals:
-    Nutriment:
-      Min: 1
-      Max: 20
-      PotencyDivisor: 20
-    Oats:
-      Min: 5
-      Max: 20
-      PotencyDivisor: 20
+  plantTraits:
+    !type:PlantTraitsComponent
+      endurance: 100
+      yield: 3
+      lifespan: 25
+      maturation: 6
+      production: 3
+      growthStages: 6
+      potency: 5
+      seedless: false
+      ligneous: false
+      viable: true
+  plantCosmetics:
+    !type:PlantCosmeticsComponent
+      plantRsi: Objects/Specific/Hydroponics/oat.rsi
+      plantIconState: produce
+      canScream: false
+      turnIntoKudzu: false
+  plantChemicals:
+    !type:PlantChemicalsComponent
+      chemicals:
+        Nutriment:
+          Min: 1
+          Max: 20
+          PotencyDivisor: 20
+          Inherent: true
+        Oats:
+          Min: 5
+          Max: 20
+          PotencyDivisor: 20
+          Inherent: true
+  plantProducts:
+    !type:PlantProductsComponent
+      productPrototypes:
+        - OatBushel
+      packetPrototype: OatSeeds
+  harvest:
+    !type:HarvestComponent
+      harvestRepeat: NoRepeat
 
 - type: seed
   id: banana
   name: seeds-banana-name
   noun: seeds-noun-seeds
   displayName: seeds-banana-display-name
-  plantRsi: Objects/Specific/Hydroponics/banana.rsi
-  packetPrototype: BananaSeeds
-  productPrototypes:
-    - FoodBanana
   mutationPrototypes:
     - mimana
-  harvestRepeat: Repeat
-  lifespan: 50
-  maturation: 6
-  production: 6
-  yield: 2
   growthComponents:
     - !type:BasicGrowthComponent
         waterConsumption: 0.6
     - !type:AtmosphericGrowthComponent
         idealHeat: 298
-  chemicals:
-    Vitamin:
-      Min: 1
-      Max: 4
-      PotencyDivisor: 25
-    Nutriment:
-      Min: 1
-      Max: 2
-      PotencyDivisor: 50
+  plantTraits:
+    !type:PlantTraitsComponent
+      endurance: 100
+      yield: 2
+      lifespan: 50
+      maturation: 6
+      production: 6
+      growthStages: 6
+      potency: 1
+      seedless: false
+      ligneous: false
+      viable: true
+  plantCosmetics:
+    !type:PlantCosmeticsComponent
+      plantRsi: Objects/Specific/Hydroponics/banana.rsi
+      plantIconState: produce
+      canScream: false
+      turnIntoKudzu: false
+  plantChemicals:
+    !type:PlantChemicalsComponent
+      chemicals:
+        Vitamin:
+          Min: 1
+          Max: 4
+          PotencyDivisor: 25
+          Inherent: true
+        Nutriment:
+          Min: 1
+          Max: 2
+          PotencyDivisor: 50
+          Inherent: true
+  plantProducts:
+    !type:PlantProductsComponent
+      productPrototypes:
+        - FoodBanana
+      packetPrototype: BananaSeeds
+  harvest:
+    !type:HarvestComponent
+      harvestRepeat: Repeat
 
 - type: seed
   id: mimana

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -16,6 +16,7 @@
         production: 3
         growthStages: 6
         potency: 5
+    - !type:HarvestComponent
         harvestRepeat: NoRepeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/wheat.rsi
@@ -50,6 +51,7 @@
         production: 3
         growthStages: 6
         potency: 5
+    - !type:HarvestComponent
         harvestRepeat: NoRepeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/meatwheat.rsi
@@ -84,6 +86,7 @@
         production: 3
         growthStages: 6
         potency: 5
+    - !type:HarvestComponent
         harvestRepeat: NoRepeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/oat.rsi
@@ -122,6 +125,7 @@
         production: 6
         growthStages: 6
         potency: 1
+    - !type:HarvestComponent
         harvestRepeat: Repeat
   plantCosmetics:
     plantRsi: Objects/Specific/Hydroponics/banana.rsi


### PR DESCRIPTION
```pr_request_template><!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR refactors the Botany system by moving plant-related data from `SeedData` into new, dedicated ECS components and implements a new `HarvestSystem`.

## Why / Balance
This is a significant step towards improving Botany's ECS support, as outlined in the [Botany ECS Design Document](https://github.com/space-wizards/docs/pull/290). By breaking down `SeedData` into modular components and introducing a dedicated `HarvestSystem`, the system becomes much more flexible and expandable. This allows for easier addition of new plant behaviors, mutations, and interactions in the future. Balance is largely unchanged, as this is primarily a system port and refactor.

## Technical details
-   **New Components**:
    -   `PlantTraitsComponent`: Stores core plant characteristics (Endurance, Yield, Lifespan, Maturation, Production, GrowthStages, Potency, Seedless, Ligneous, Viable).
    -   `PlantCosmeticsComponent`: Stores visual and audio properties (PlantRsi, PlantIconState, ScreamSound, CanScream, KudzuPrototype, TurnIntoKudzu).
    -   `PlantChemicalsComponent`: Stores chemical production data.
    -   `PlantProductsComponent`: Stores product and packet prototypes.
    -   `HarvestComponent`: Manages harvest behavior (HarvestRepeat, ReadyForHarvest, LastHarvestTime).
-   **New System**:
    -   `HarvestSystem`: Handles all plant harvesting logic, including spawning produce, applying mutations to produce, and managing harvest types (NoRepeat, Repeat, SelfHarvest).
-   **Refactored `SeedData`**: Old fields have been removed and replaced with references to the new components. `Clone()` and `SpeciesChange()` methods have been updated to handle component copying and merging.
-   **Updated Systems**: `MutationSystem`, `PlantHolderSystem`, `BasicGrowthSystem`, and `BotanySystem.Produce.cs` have been updated to primarily use the new components.
-   **Backward Compatibility**: Existing `SeedData` fields are still checked as a fallback if the new components are not present, ensuring old prototypes continue to function.
-   **Prototype Migration**: Initial seed prototypes (wheat, meatwheat, oat, banana) have been updated to use the new component structure.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No direct ingame changes visible to the player, only backend refactoring.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.io/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
-   **`SeedData` fields**: Many fields in `SeedData` have been removed and replaced by new components (`PlantTraitsComponent`, `PlantCosmeticsComponent`, `PlantChemicalsComponent`, `PlantProductsComponent`, `HarvestComponent`).
    -   **Fixing**: Existing seed prototypes in YAML should be updated to use the new component structure. The system includes backward compatibility for older prototypes, but migrating them is recommended.
-   **Harvest Logic**: The core harvest logic has moved from `PlantHolderSystem` to the new `HarvestSystem` and `HarvestComponent`. Direct calls to `PlantHolderSystem.DoHarvest` might need review if they bypass the new component system.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Refactored Botany's plant data and harvest system to use a more modular ECS component-based approach, improving future expandability.

---
<a href="https://cursor.com/background-agent?bcId=bc-90f2d324-62fa-4591-a7d7-acfcda38b7db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90f2d324-62fa-4591-a7d7-acfcda38b7db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>