### PR TITLE
Исправить копирование параметров из родительского компонента

### DIFF
--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -155,7 +155,7 @@ public sealed partial class BotanySystem : EntitySystem
 
             var yieldMod = Comp<PlantHolderComponent>(plantEntity!.Value).YieldMod;
 
-            return GenerateProduct(proto, position, yieldMod);
+            return GenerateProduct(proto, position, yieldMod, plantEntity);
         }
 
         return Enumerable.Empty<EntityUid>();
@@ -178,10 +178,10 @@ public sealed partial class BotanySystem : EntitySystem
 
         var yieldMod = Comp<PlantHolderComponent>(plantEntity!.Value).YieldMod;
 
-        return GenerateProduct(proto, Transform(user).Coordinates, yieldMod);
+        return GenerateProduct(proto, Transform(user).Coordinates, yieldMod, plantEntity);
     }
 
-    public IEnumerable<EntityUid> GenerateProduct(SeedData proto, EntityCoordinates position, int yieldMod = 1)
+    public IEnumerable<EntityUid> GenerateProduct(SeedData proto, EntityCoordinates position, int yieldMod = 1, EntityUid? plantEntity = null)
     {
         var traits = GetPlantTraits(proto);
         if (traits == null)
@@ -215,6 +215,23 @@ public sealed partial class BotanySystem : EntitySystem
             var produce = EnsureComp<ProduceComponent>(entity);
 
             produce.Seed = proto.Clone();
+            
+            // Copy growth components from the plant to the seed if plantEntity is provided
+            if (plantEntity != null && EntityManager.EntityExists(plantEntity.Value))
+            {
+                var plantGrowthComponents = EntityManager.GetComponents<PlantGrowthComponent>(plantEntity.Value).ToList();
+                produce.Seed.GrowthComponents.Clear();
+                foreach (var component in plantGrowthComponents)
+                {
+                    var newComponent = component.DupeComponent();
+                    produce.Seed.GrowthComponents.Add(newComponent);
+                }
+                
+                // Log for debugging
+                _adminLogger.Add(LogType.Botany, LogImpact.Low, 
+                    $"Copied {plantGrowthComponents.Count} growth components from plant {plantEntity.Value} to seed {produce.Seed.Name}");
+            }
+            
             ProduceGrown(entity, produce);
 
             _appearance.SetData(entity, ProduceVisuals.Potency, traits.Potency);

--- a/Content.Tests/Server/BotanyComponentCopyTest.cs
+++ b/Content.Tests/Server/BotanyComponentCopyTest.cs
@@ -1,0 +1,88 @@
+using Content.Server.Botany.Components;
+using Content.Server.Botany.Systems;
+using Content.Shared.Botany;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.UnitTesting;
+
+namespace Content.Tests.Server
+{
+    [TestFixture]
+    public class BotanyComponentCopyTest : ContentUnitTest
+    {
+        private BotanySystem _botanySystem = default!;
+        private PlantHolderSystem _plantHolderSystem = default!;
+        private EntityUid _plantEntity;
+        private EntityUid _userEntity;
+
+        [SetUp]
+        public void Setup()
+        {
+            _botanySystem = new BotanySystem();
+            _plantHolderSystem = new PlantHolderSystem();
+            
+            // Register systems
+            var entMan = IoCManager.Resolve<IEntityManager>();
+            entMan.AddSystem(_botanySystem);
+            entMan.AddSystem(_plantHolderSystem);
+            
+            // Create test entities
+            _plantEntity = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+            _userEntity = entMan.SpawnEntity(null, MapCoordinates.Nullspace);
+        }
+
+        [Test]
+        public void TestComponentCopyOnHarvest()
+        {
+            var entMan = IoCManager.Resolve<IEntityManager>();
+            
+            // Add PlantHolderComponent to plant
+            var plantHolder = entMan.AddComponent<PlantHolderComponent>(_plantEntity);
+            
+            // Create a test seed with components
+            var seed = new SeedData
+            {
+                Name = "test-seed",
+                GrowthComponents = new List<PlantGrowthComponent>
+                {
+                    new PlantTraitsComponent
+                    {
+                        Lifespan = 100,
+                        Maturation = 10,
+                        Production = 5,
+                        Yield = 3,
+                        Potency = 20
+                    }
+                }
+            };
+            
+            plantHolder.Seed = seed;
+            
+            // Add components to plant entity
+            entMan.AddComponent<PlantTraitsComponent>(_plantEntity);
+            entMan.AddComponent<BasicGrowthComponent>(_plantEntity);
+            
+            // Test that components are copied during harvest
+            var products = _botanySystem.GenerateProduct(seed, MapCoordinates.Nullspace, 1, _plantEntity);
+            
+            Assert.That(products, Is.Not.Empty);
+            
+            foreach (var product in products)
+            {
+                var produce = entMan.GetComponent<ProduceComponent>(product);
+                Assert.That(produce.Seed, Is.Not.Null);
+                Assert.That(produce.Seed.GrowthComponents, Is.Not.Empty);
+                
+                // Check that PlantTraitsComponent was copied
+                var traitsComponent = produce.Seed.GrowthComponents.OfType<PlantTraitsComponent>().FirstOrDefault();
+                Assert.That(traitsComponent, Is.Not.Null);
+                Assert.That(traitsComponent.Lifespan, Is.EqualTo(100));
+                Assert.That(traitsComponent.Maturation, Is.EqualTo(10));
+                Assert.That(traitsComponent.Production, Is.EqualTo(5));
+                Assert.That(traitsComponent.Yield, Is.EqualTo(3));
+                Assert.That(traitsComponent.Potency, Is.EqualTo(20));
+            }
+        }
+    }
+}


### PR DESCRIPTION
```pr_request_template>
## About the PR
Fixes a regression where `PlantGrowthComponent` data (e.g., `PlantTraitsComponent` values like lifespan, maturation, production, yield, potency) was not being copied from the harvested plant to its seeds.

## Why / Balance
Before a refactor, plant traits were directly on `SeedData` and copied. After moving them to `PlantTraitsComponent`, this copying stopped, meaning harvested seeds would lose the specific traits of their parent plant. This PR restores the intended behavior, ensuring that plant characteristics are propagated to new seeds, which is crucial for dynamic botany gameplay and breeding.

## Technical details
- Modified `BotanySystem.GenerateProduct` to accept an optional `EntityUid? plantEntity` parameter.
- Added logic within `GenerateProduct` to iterate over `PlantGrowthComponent`s on the provided `plantEntity` and `DupeComponent()` them into the `SeedData.GrowthComponents` of the newly created seed.
- Updated all internal calls to `GenerateProduct` (in `AutoHarvest` and `Harvest`) to pass the `plantEntity`.
- Added a new unit test `BotanyComponentCopyTest` to verify the component copying functionality.

## Media
- [X] I have added media to this PR or it does not require an ingame showcase.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
- The signature of `BotanySystem.GenerateProduct` has changed to include an optional `plantEntity` parameter. Any external code directly calling this method will need to be updated.

**Changelog**
:cl:
- fix: Fixed plant traits (lifespan, maturation, production, yield, potency) not being copied to seeds upon harvest.
</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-6489e98e-4b74-4ee6-81fa-ee4135144666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6489e98e-4b74-4ee6-81fa-ee4135144666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>